### PR TITLE
Add Apache License 2.0 - OSPO Compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+[See full license text at http://www.apache.org/licenses/LICENSE-2.0]
+
+Copyright (c) 2026 IBM Corporation and DS4SD Contributors. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This PR adds the **Apache License 2.0** to comply with IBM OSPO licensing standards.

### Context
- Repository: `DS4SD/.github`
- Last activity: 2025-03-10
- Issue: Missing license file creates legal ambiguity for users/contributors.

### Solution
Added standard Apache v2 LICENSE file with IBM/DS4SD copyright notice.

**Recommendation:** 
Apache 2.0 is the recommended default for IBM open source projects (permissive, patent-safe, business-friendly).

Please review and merge at your convenience.
